### PR TITLE
Throw friendlier error when a reference cannot be found.

### DIFF
--- a/lib/waterline-schema/references.js
+++ b/lib/waterline-schema/references.js
@@ -78,6 +78,9 @@ References.prototype.addKeys = function(collection) {
  */
 
 References.prototype.findReference = function(parent, collection) {
+  if(typeof this.collections[collection] != 'object') {
+      throw new Error('Cannot find collection \'' + collection + '\' referenced in ' + parent);
+  }
   var attributes = this.collections[collection].attributes,
       reference;
 


### PR DESCRIPTION
If a model references a deleted or non-existent model 

Error: Cannot find collection 'place' referenced in user

is easier to debug than

TypeError: Cannot read property 'attributes' of undefined
