### PR TITLE
Throw Explicit Errors when Collection is not defined

### DIFF
--- a/lib/waterline-schema/foreignKeys.js
+++ b/lib/waterline-schema/foreignKeys.js
@@ -74,7 +74,7 @@ ForeignKeys.prototype.findPrimaryKey = function(collection) {
   if(!this.collections[collection]) {
     throw new Error('Trying to access a collection ' + collection + ' that is not defined.');
   }
-  if(!this.collections[collection].attributes)  {
+  if(!this.collections[collection].attributes) {
     throw new Error('Collection, ' + collection + ', has no attributes defined.');
   }
 

--- a/lib/waterline-schema/joinTables.js
+++ b/lib/waterline-schema/joinTables.js
@@ -290,7 +290,7 @@ JoinTables.prototype.findPrimaryKey = function(collection) {
   if(!this.collections[collection]) {
     throw new Error('Trying to access a collection ' + collection + ' that is not defined.');
   }
-  if(!this.collections[collection].attributes)  {
+  if(!this.collections[collection].attributes) {
     throw new Error('Collection, ' + collection + ', has no attributes defined.');
   }
 


### PR DESCRIPTION
findPrimaryKey throws an Error when the primary key cannot be located but not when the
collection itself is not defined. Seems like a mismatch. Also causes dumb developers like
myself much grief when they accidentally have a typo in a name. A more explicit error
should help quite a bit.  Without it, the code just bombs out with a far more nebulous stack
trace.

Lastly, may want to consider consolidating these two findPrimaryKey functions into a single
place as they appear to be identical. Decided not to take a stab at DRYing this for the sake of
having a simpler pull request.
