### PR TITLE
Support embeddable association (denormalization)

### DIFF
--- a/lib/waterline-schema/foreignKeys.js
+++ b/lib/waterline-schema/foreignKeys.js
@@ -57,7 +57,8 @@ ForeignKeys.prototype.replaceKeys = function(attributes) {
       type: primaryKey.attributes.type,
       foreignKey: true,
       references: modelName,
-      on: primaryKey.attributes.columnName || primaryKey.name
+      on: primaryKey.attributes.columnName || primaryKey.name,
+      embed: attributes[attribute].embed || false
     };
 
     // Remove the attribute and replace it with the foreign key

--- a/lib/waterline-schema/utils.js
+++ b/lib/waterline-schema/utils.js
@@ -23,7 +23,8 @@ exports.reservedWords = [
   'collection',
   'model',
   'via',
-  'dominant'
+  'dominant',
+  'embed'
 ];
 
 /**


### PR DESCRIPTION
With certain commits in `waterline`, association can be set to
embeddable using `embed` keyword. And if so, the associating model can
be fully or partially embedded. This is denormalization, an only works
with `sails-mongo` currently.

https://github.com/balderdashy/waterline/issues/427