### PR TITLE
Change Attributes collections param to an array

### DIFF
--- a/lib/waterline-schema/attributes.js
+++ b/lib/waterline-schema/attributes.js
@@ -19,7 +19,7 @@ module.exports = Attributes;
  * Takes a collection of attributes from a Waterline Collection
  * and builds up an initial schema by normalizing into a known format.
  *
- * @param {Object} collections
+ * @param {Array} collections
  * @param {Object} connections
  * @return {Object}
  * @api private
@@ -33,22 +33,22 @@ function Attributes(collections, connections, defaults) {
   // Ensure a value is set for connections
   connections = connections || {};
 
-  for(var key in collections) {
-    var collection = this.normalize(collections[key].prototype, connections, defaults);
+  collections.forEach(function (collection) {
+    collection = self.normalize(collection.prototype, connections, defaults);
     var conns = _.cloneDeep(collection.connection);
     var attributes = _.cloneDeep(collection.attributes);
 
-    this.stripFunctions(attributes);
-    this.stripProperties(attributes);
-    this.validatePropertyNames(attributes);
+    self.stripFunctions(attributes);
+    self.stripProperties(attributes);
+    self.validatePropertyNames(attributes);
 
-    this.attributes[collection.identity.toLowerCase()] = {
+    self.attributes[collection.identity.toLowerCase()] = {
       connection: conns,
       identity: collection.identity.toLowerCase(),
       tableName: collection.tableName || collection.identity,
       attributes: attributes
     };
-  }
+  });
 
   return this.attributes;
 

--- a/test/attributes.js
+++ b/test/attributes.js
@@ -22,7 +22,7 @@ describe('Attributes', function() {
     });
 
     it('should build an attributes definition containing two keys', function() {
-      var obj = new Attributes({ foo: collection });
+      var obj = new Attributes([collection]);
 
       assert(obj.foo);
       assert(Object.keys(obj.foo.attributes).length === 2);
@@ -31,12 +31,12 @@ describe('Attributes', function() {
     });
 
     it('should strip functions', function() {
-      var obj = new Attributes({ foo: collection });
+      var obj = new Attributes([collection]);
       assert(!obj.foo.attributes.fn);
     });
 
     it('should set defaults for adapters', function() {
-      var obj = new Attributes({ foo: collection });
+      var obj = new Attributes([collection]);
       assert(obj.foo.connection === '');
     });
   });
@@ -63,7 +63,7 @@ describe('Attributes', function() {
 
     it('should add auto attributes to the definition', function() {
       var coll = collectionFn();
-      var obj = new Attributes({ foo: coll });
+      var obj = new Attributes([coll]);
       assert(obj.foo);
       assert(Object.keys(obj.foo.attributes).length === 5);
       assert(obj.foo.attributes.foo);
@@ -75,7 +75,7 @@ describe('Attributes', function() {
 
     it('should inject flags into the collection', function() {
       var coll = collectionFn();
-      var obj = new Attributes({ foo: coll });
+      var obj = new Attributes([coll]);
 
       assert(coll.prototype.autoPK);
       assert(coll.prototype.autoCreatedAt);
@@ -84,13 +84,13 @@ describe('Attributes', function() {
 
     it('should normalize tableName to identity', function() {
       var coll = collectionFn();
-      var obj = new Attributes({ foo: coll });
+      var obj = new Attributes([coll]);
       assert(coll.prototype.identity === 'foo');
     });
 
     it('should add a primary key field', function() {
       var coll = collectionFn();
-      var obj = new Attributes({ foo: coll });
+      var obj = new Attributes([coll]);
       assert(obj.foo.attributes.id);
       assert(obj.foo.attributes.id.primaryKey);
       assert(obj.foo.attributes.id.unique);
@@ -98,7 +98,7 @@ describe('Attributes', function() {
 
     it('should add in timestamps', function() {
       var coll = collectionFn();
-      var obj = new Attributes({ foo: coll });
+      var obj = new Attributes([coll]);
       assert(obj.foo.attributes.createdAt);
       assert(obj.foo.attributes.updatedAt);
     });
@@ -121,7 +121,7 @@ describe('Attributes', function() {
     it('should error with message', function() {
       assert.throws(
         function() {
-          new Attributes({ foo: collection });
+          new Attributes([collection]);
         }
       );
     });


### PR DESCRIPTION
Latest Waterline master passes the collections to Schema() in as an
array. Schema() is documented to take the collections in as an array,
too. Updating Attributes() to match.

The original code actually almost works, unless some library
monkey-patches Array to add a method to it. The Attributes tries to
process the function as a collection, and hilarity ensues.
