### PR TITLE
Throw and show error on console when `via` attribute doesn't exist in th...

### DIFF
--- a/lib/waterline-schema/joinTables.js
+++ b/lib/waterline-schema/joinTables.js
@@ -140,6 +140,14 @@ JoinTables.prototype.parseAttribute = function(collectionName, attribute) {
     throw new Error(error);
   }
 
+  if (!hop(child.attributes, attr.via)) {
+    error = 'Collection ' + collectionName + ' has an attribute named ' + attribute.key + ' that is ' +
+            'pointing to a collection named ' + attr.collection + ' via an attribute named' + attr.via + ' which doesn\'t exist. You must ' +
+            ' first create the ' + attr.via + ' attribute in the ' + attr.collection + ' collection.';
+
+    throw new Error(error);
+  }
+
   // If the attribute has a `via` key, check if it's a foreign key. If so this is a one-to-many
   // relationship and no join table is needed.
   if(hop(attr, 'via') && hop(child.attributes[attr.via], 'foreignKey')) return;


### PR DESCRIPTION
Throw and show error on console when `via` attribute doesn't exist in the associated collection. E.g.:

```
// User.js
pets: { collection: 'Pet', via: 'user' } //----> should be via `owner` not `user`

// Pet.js
owner: { model: 'User' }
```
