### PR TITLE
Adds custom automatic attribute names

### DIFF
--- a/lib/waterline-schema/attributes.js
+++ b/lib/waterline-schema/attributes.js
@@ -123,6 +123,16 @@ Attributes.prototype.setDefaults = function(collection, defaults) {
     migrate: defaultSettings.migrate
   };
 
+  // Set the property for the automatic attributes if the user didn't
+  // customize it/disable it.
+  if(flags.autoCreatedAt === true) {
+    flags.autoCreatedAt = 'createdAt';
+  }
+
+  if(flags.autoUpdatedAt === true) {
+    flags.autoUpdatedAt = 'updatedAt';
+  }
+
   for(var flag in flags) {
     collection[flag] = flags[flag];
   }
@@ -205,12 +215,12 @@ Attributes.prototype.autoAttributes = function(collection, connections) {
     'default': 'NOW'
   };
 
-  if(collection.autoCreatedAt && !attributes.createdAt) {
-    attributes.createdAt = now;
+  if(collection.autoCreatedAt && !attributes[collection.autoCreatedAt]) {
+    attributes[collection.autoCreatedAt] = now;
   }
 
-  if(collection.autoUpdatedAt && !attributes.updatedAt) {
-    attributes.updatedAt = now;
+  if(collection.autoUpdatedAt && !attributes[collection.autoUpdatedAt]) {
+    attributes[collection.autoUpdatedAt] = now;
   }
 
 };

--- a/test/attributes.js
+++ b/test/attributes.js
@@ -104,6 +104,56 @@ describe('Attributes', function() {
     });
   });
 
+  describe('with custom automatic attribute names', function() {
+    var collectionFn;
+
+    before(function() {
+      collectionFn = function() {
+        var collection = function() {};
+        collection.prototype = {
+          tableName: 'FOO',
+          autoCreatedAt: 'customCreatedAt',
+          autoUpdatedAt: 'customUpdatedAt',
+          attributes: {
+            foo: 'string',
+            bar: 'string',
+            fn: function() {}
+          }
+        };
+
+        return collection;
+      };
+    });
+
+    it('should add auto attributes to the definition', function() {
+      var coll = collectionFn();
+      var obj = new Attributes([coll]);
+      assert(obj.foo);
+      assert(Object.keys(obj.foo.attributes).length === 5);
+      assert(obj.foo.attributes.foo);
+      assert(obj.foo.attributes.bar);
+      assert(obj.foo.attributes.id);
+      assert(obj.foo.attributes.customCreatedAt);
+      assert(obj.foo.attributes.customUpdatedAt);
+    });
+
+    it('should inject the custom names into the collection', function() {
+      var coll = collectionFn();
+      var obj = new Attributes([coll]);
+
+      assert(coll.prototype.autoPK);
+      assert(coll.prototype.autoCreatedAt);
+      assert(coll.prototype.autoUpdatedAt);
+    });
+
+    it('should add in timestamps', function() {
+      var coll = collectionFn();
+      var obj = new Attributes([coll]);
+      assert(obj.foo.attributes.customCreatedAt);
+      assert(obj.foo.attributes.customUpdatedAt);
+    });
+  });
+
   describe('with invalid attribute name', function() {
     var collection;
 


### PR DESCRIPTION
Implements [https://github.com/balderdashy/waterline/issues/754](https://github.com/balderdashy/waterline/issues/754)

This pull request adds a way for user to specify the attribute names they want for the automatic timestamp attributes, example : 

```javascript
collection = function() {};
collection.prototype = {
  tableName: 'Foo',
  autoCreatedAt: 'customCreatedAt',
  autoUpdatedAt: 'customUpdatedAt',
  attributes: {
    foo: 'string',
    bar: 'string'
  }
};
```

This way it will add the attributes `customCreatedAt` and  `customUpdatedAt` with the right automatic timestamp behaviors.