### PR TITLE
Fix association on junction table between the same model.

### DIFF
--- a/lib/waterline-schema/joinTables.js
+++ b/lib/waterline-schema/joinTables.js
@@ -483,7 +483,8 @@ JoinTables.prototype.markCustomJoinTables = function(collection) {
     attributes[attribute].references = linkedCollection;
 
     // Find Reference Key
-    var reference = this.findReference(collection, linkedCollection);
+    var via = attributes[attribute].via;
+    var reference = this.findReference(collection, linkedCollection, via);
     attributes[attribute].on = reference;
     attributes[attribute].onKey = reference;
 
@@ -501,7 +502,7 @@ JoinTables.prototype.markCustomJoinTables = function(collection) {
  * @api private
  */
 
-JoinTables.prototype.findReference = function(parent, collection) {
+JoinTables.prototype.findReference = function(parent, collection, via) {
 
   var attributes = this.collections[collection].attributes;
   var reference;
@@ -510,6 +511,7 @@ JoinTables.prototype.findReference = function(parent, collection) {
     if(!hop(attributes[attribute], 'foreignKey')) continue;
     if(!hop(attributes[attribute], 'references')) continue;
     if(attributes[attribute].references !== parent) continue;
+    if(via && via !== attribute) continue;
 
     reference = attributes[attribute].columnName || attribute;
     break;
@@ -584,5 +586,3 @@ JoinTables.prototype.filterMigrateSafeTables = function() {
 
   return this.tables;
 };
-
-

--- a/test/joinTables.js
+++ b/test/joinTables.js
@@ -373,4 +373,67 @@ describe('JoinTables', function() {
     });
   });
 
+
+  describe('junction table between the same model', function() {
+    var collections = {};
+
+    before(function() {
+
+      collections.foo = {
+        tableName: 'foo',
+        connection: 'foo',
+        migrate: 'safe',
+        attributes: {
+          id: {
+            type: 'integer',
+            autoIncrement: true,
+            primaryKey: true,
+            unique: true
+          }
+        },
+        follows: {
+          collection: 'foo',
+          through: 'bar',
+          via: 'from'
+        },
+        followers: {
+          collection: 'foo',
+          through: 'bar',
+          via: 'from'
+        }
+      };
+
+      collections.bar = {
+        tableName: 'bar',
+        connection: 'bar',
+        migrate: 'safe',
+        attributes: {
+          to: {
+            foreignKey: true,
+            references: 'foo',
+            on: 'id',
+            onKey: 'id',
+            via: 'from'
+          },
+          from: {
+            foreignKey: true,
+            references: 'foo',
+            on: 'id',
+            onKey: 'id',
+            via: 'to'
+          }
+        }
+      }
+    });
+
+    it('should join to collect attributes', function() {
+      var obj = new JoinTables(collections);
+
+      assert(obj.foo.follows.onKey !== 'from');
+      assert(obj.foo.follows.on !== 'from');
+
+      assert(obj.foo.followers.onKey !== 'to');
+      assert(obj.foo.followers.on !== 'to');
+    });
+  });
 });

--- a/test/joinTables.js
+++ b/test/joinTables.js
@@ -389,17 +389,17 @@ describe('JoinTables', function() {
             autoIncrement: true,
             primaryKey: true,
             unique: true
+          },
+          follows: {
+            collection: 'foo',
+            through: 'bar',
+            via: 'to'
+          },
+          followers: {
+            collection: 'foo',
+            through: 'bar',
+            via: 'from'
           }
-        },
-        follows: {
-          collection: 'foo',
-          through: 'bar',
-          via: 'from'
-        },
-        followers: {
-          collection: 'foo',
-          through: 'bar',
-          via: 'from'
         }
       };
 
@@ -433,11 +433,11 @@ describe('JoinTables', function() {
     it('should join to collect attributes', function() {
       var obj = new JoinTables(collections);
 
-      assert(obj.foo.follows.onKey !== 'from');
-      assert(obj.foo.follows.on !== 'from');
+      assert.equal(obj.foo.attributes.follows.onKey, 'to');
+      assert.equal(obj.foo.attributes.follows.on, 'to');
 
-      assert(obj.foo.followers.onKey !== 'to');
-      assert(obj.foo.followers.on !== 'to');
+      assert.equal(obj.foo.attributes.followers.onKey, 'from');
+      assert.equal(obj.foo.attributes.followers.on, 'from');
     });
   });
 });

--- a/test/joinTables.js
+++ b/test/joinTables.js
@@ -407,6 +407,10 @@ describe('JoinTables', function() {
         tableName: 'bar',
         connection: 'bar',
         migrate: 'safe',
+
+        junctionTable: true,
+        tables: ['foo', 'foo'],
+
         attributes: {
           to: {
             foreignKey: true,


### PR DESCRIPTION
This pull request fix association on junction table between the same model.

example:

``` node
// user.js
module.exports = {
  tableName: 'users',
  attributes: {
    name: 'string',
    follows: {
      collection: 'users',
      through: 'follow',
      via: 'from'
    },
    followers: {
      collection: 'users',
      through: 'follow',
      via: 'to'
    }
}

// follow.js
module.exports = {

  tableName: 'follows',
  tables: ['users', 'users'],
  junctionTable: true,

  attributes: {
    to: {
      columnName: 'to',
      foreignKey: true,
      references: 'user',
      on: 'id',
      onKey: 'id',
      via: 'from'
    },
    from: {
      columnName: 'from',
      foreignKey: true,
      references: 'user',
      on: 'id',
      onKey: 'id',
      via: 'to'
    }
  }
};
```

The current version always use `via to` association. 