### PR TITLE
Many-to-Many through fix

### DIFF
--- a/lib/waterline-schema/joinTables.js
+++ b/lib/waterline-schema/joinTables.js
@@ -476,7 +476,11 @@ JoinTables.prototype.markCustomJoinTables = function(collection) {
     if(!hop(attributes[attribute], 'through')) continue;
 
     var linkedCollection = attributes[attribute].through;
+
+    // Flag as both a junction table AND a through table
+    // This allows Waterline to make it available as an actual model
     this.collections[linkedCollection].junctionTable = true;
+    this.collections[linkedCollection].throughTable = true;
 
     // Build up proper reference on the attribute
     attributes[attribute].collection = linkedCollection;
@@ -485,6 +489,7 @@ JoinTables.prototype.markCustomJoinTables = function(collection) {
     // Find Reference Key
     var via = attributes[attribute].via;
     var reference = this.findReference(collection, linkedCollection, via);
+
     attributes[attribute].on = reference;
     attributes[attribute].onKey = reference;
 

--- a/test/fixtures/many-many-through.js
+++ b/test/fixtures/many-many-through.js
@@ -1,0 +1,47 @@
+module.exports = [
+
+  {
+    connection: 'f',
+    identity: 'user',
+    tableName: 'user',
+    migrate: 'alter',
+    attributes: {
+      cars: {
+        collection: 'car',
+        through: 'drive',
+        via: 'user'
+      }
+    }
+  },
+
+  {
+    connection: 'f',
+    identity: 'drive',
+    tableName: 'drive',
+    migrate: 'alter',
+    attributes: {
+      car: {
+        model: 'car'
+      },
+      user: {
+        model: 'user'
+      }
+    }
+  },
+
+  {
+    connection: 'f',
+    identity: 'car',
+    tableName: 'car',
+    migrate: 'alter',
+    attributes: {
+      drivers: {
+        collection: 'user',
+        through: 'drive',
+        via: 'car'
+      }
+    }
+  }
+
+
+];

--- a/test/hasManyThrough.js
+++ b/test/hasManyThrough.js
@@ -1,9 +1,33 @@
-var References = require('../lib/waterline-schema/references'),
-    assert = require('assert');
+var assert = require('assert');
+var _ = require('lodash');
+
+var Schema = require('../lib/waterline-schema');
+var References = require('../lib/waterline-schema/references');
+var fixtures = require('./fixtures/many-many-through');
 
 describe('Has Many Through', function() {
 
-  describe('Should Add', function() {
+  describe('junction table config', function() {
+    var collections = [];
+
+    before(function() {
+      _.each(fixtures, function(fixture) {
+        var coll = function() {};
+        coll.prototype = fixture;
+        collections.push(coll);
+      });
+    });
+
+    it('should flag the "through" table as both a junction table and through table', function() {
+      var schema = new Schema(collections);
+      var junctionTable = schema.drive;
+
+      assert(junctionTable.junctionTable);
+      assert(junctionTable.throughTable);
+    });
+  });
+
+  describe('reference mapping', function() {
     var collections = {};
 
     before(function() {

--- a/test/joinTables.js
+++ b/test/joinTables.js
@@ -255,6 +255,7 @@ describe('JoinTables', function() {
     });
   });
 
+
   describe('migrate safe should not flag a join table as "alter"', function() {
     var collections = {};
 
@@ -313,6 +314,7 @@ describe('JoinTables', function() {
       assert(obj.bar.attributes.foos.on === 'bar_foos');
     });
   });
+
 
   describe('migrate safe should not flag a join table as "alter" when specified on only one collection', function() {
     var collections = {};


### PR DESCRIPTION
This is an alternative to #30. Here we are flagging the table as both a `junctionTable` and a `throughTable`. This should allow us to patch the issue in Waterline where custom built join tables were being processed incorrectly on initialize.

More info here: https://github.com/balderdashy/waterline/issues/1133#issuecomment-158526482

cc @atiertant