### PR TITLE
Pass the meta object down to the generated join tables

### DIFF
--- a/lib/waterline-schema/attributes.js
+++ b/lib/waterline-schema/attributes.js
@@ -47,7 +47,8 @@ function Attributes(collections, connections, defaults) {
       identity: collection.identity.toLowerCase(),
       tableName: collection.tableName || collection.identity,
       migrate: collection.migrate || 'safe',
-      attributes: attributes
+      attributes: attributes,
+      meta: collection.meta || {}
     };
   });
 

--- a/lib/waterline-schema/joinTables.js
+++ b/lib/waterline-schema/joinTables.js
@@ -198,6 +198,22 @@ JoinTables.prototype.buildTable = function(columns) {
   table.joinedAttributes = [];
   table.junctionTable = true;
 
+  // Append the meta data if defined.
+  // To do this, find the dominant collection or just use C1 and then merge the
+  // two meta objects together with the dominant side taking precedence.
+  var dominantCollection;
+  var nonDominantCollection;
+  if(this.searchForAttribute(c2.collection, 'dominant')) {
+    dominantCollection = c2.collection;
+    nonDominantCollection = c1.collection;
+  } else {
+    dominantCollection = c1.collection;
+    nonDominantCollection = c2.collection;
+  }
+
+  var metaData = _.merge({}, (this.collections[nonDominantCollection].meta || {}), (this.collections[dominantCollection].meta || {}));
+  table.meta = metaData;
+
   // Look for a dominant collection property so the join table can be created on the correct connection.
   table.connection = this.findDominantConnection(columns);
   if(!table.connection) {

--- a/test/metaData.js
+++ b/test/metaData.js
@@ -1,0 +1,112 @@
+var assert = require('assert');
+var Schema = require('../lib/waterline-schema');
+var _ = require('lodash');
+
+describe('Meta Extended Data', function() {
+
+  describe('on tables', function() {
+
+    var collections = [];
+
+    before(function() {
+
+      var fixtures = [{
+        connection: 'f',
+        identity: 'user',
+        tableName: 'user',
+        migrate: 'alter',
+        meta: {
+          schemaName: 'foo'
+        },
+        attributes: {
+          name: {
+            type: 'string'
+          }
+        }
+      },
+      {
+        connection: 'f',
+        identity: 'car',
+        tableName: 'car',
+        migrate: 'alter',
+        attributes: {
+          age: {
+            type: 'integer'
+          }
+        }
+      }];
+
+      _.each(fixtures, function(fixture) {
+        var coll = function() {};
+        coll.prototype = fixture;
+        collections.push(coll);
+      });
+
+    });
+
+    it('should keep the meta key on the user collection', function() {
+      var schema = new Schema(collections);
+      assert(schema.user.meta);
+      assert.equal(schema.user.meta.schemaName, 'foo');
+    });
+
+    it('should add an empty meta object to the car collection', function() {
+      var schema = new Schema(collections);
+      assert(schema.car.meta);
+      assert.equal(_.keys(schema.car.meta).length, 0);
+    });
+
+
+  });
+
+  describe('On generated join tables', function() {
+    var collections = [];
+
+    before(function() {
+      var fixtures = [
+        {
+          connection: 'f',
+          identity: 'user',
+          tableName: 'user',
+          migrate: 'alter',
+          attributes: {
+            cars: {
+              collection: 'car',
+              via: 'drivers'
+            }
+          }
+        },
+        {
+          connection: 'f',
+          identity: 'car',
+          tableName: 'car',
+          migrate: 'alter',
+          meta: {
+            schemaName: 'foo'
+          },
+          attributes: {
+            drivers: {
+              collection: 'user',
+              via: 'cars',
+              dominant: true
+            }
+          }
+        }
+      ];
+
+      _.each(fixtures, function(fixture) {
+        var coll = function() {};
+        coll.prototype = fixture;
+        collections.push(coll);
+      });
+    });
+
+    it('should add the meta data to the join table', function() {
+      var schema = new Schema(collections);
+      assert(schema.car_drivers__user_cars);
+      assert(schema.car_drivers__user_cars.meta);
+      assert.equal(schema.car_drivers__user_cars.meta.schemaName, 'foo');
+    });
+
+  });
+});


### PR DESCRIPTION
In order for schema support to work in adapters like Sails-Postgresql we use the notation:

```javascript
meta: {
  schemaName: 'foo'
}
```

Which wasn't being set on join tables. This just merges the meta information from the two tables together using the side with the dominant key's metadata as the one that takes precedence.

This can be cherry picked into the `0.1.x` branch as it shouldn't be breaking.