### PR TITLE
#39: ignore columns with primaryKey set to false when determining foreignKeys

### DIFF
--- a/lib/waterline-schema/foreignKeys.js
+++ b/lib/waterline-schema/foreignKeys.js
@@ -91,7 +91,7 @@ ForeignKeys.prototype.findPrimaryKey = function(collection) {
   for(var key in this.collections[collection].attributes) {
     var attribute = this.collections[collection].attributes[key];
 
-    if(!hop(attribute, 'primaryKey')) continue;
+    if(!hop(attribute, 'primaryKey') || !attribute.primaryKey) continue;
 
     primaryKey = {
       name: key,

--- a/lib/waterline-schema/joinTables.js
+++ b/lib/waterline-schema/joinTables.js
@@ -407,7 +407,7 @@ JoinTables.prototype.findPrimaryKey = function(collection) {
   for(var key in this.collections[collection].attributes) {
     attribute = this.collections[collection].attributes[key];
 
-    if(!hop(attribute, 'primaryKey')) continue;
+    if(!hop(attribute, 'primaryKey') || !attribute.primaryKey) continue;
 
     primaryKey = {
       name: attribute.columnName || key,

--- a/test/foreignKeys.js
+++ b/test/foreignKeys.js
@@ -3,6 +3,39 @@ var ForeignKeys = require('../lib/waterline-schema/foreignKeys'),
 
 describe('ForeignKeys', function() {
 
+  describe('ignore attributes with primaryKey set to false', function() {
+    var collections = {};
+
+    before(function() {
+      collections.foo = {
+        attributes: {
+          id: {
+            type: 'integer',
+            autoIncrement: true,
+            primaryKey: true,
+            unique: true
+          },
+          count: {
+            type: 'integer',
+            primaryKey: false
+          }
+        }
+      };
+
+      collections.bar = {
+        attributes: {
+          foo: { model: 'foo' }
+        }
+      };
+    });
+
+    it('should only use the column with primaryKey set to true as foreignKey', function() {
+      var obj = new ForeignKeys(collections);
+      assert(obj.bar.attributes.foo);
+      assert(obj.bar.attributes.foo.on === 'id');
+    });
+  });
+
   describe('with automatic column names', function() {
     var collections = {};
 

--- a/test/joinTables.js
+++ b/test/joinTables.js
@@ -3,6 +3,68 @@ var JoinTables = require('../lib/waterline-schema/joinTables'),
 
 describe('JoinTables', function() {
 
+  describe('ignore attributes with primaryKey set to false', function() {
+    var collections = {};
+
+    before(function() {
+
+      collections.foo = {
+        tableName: 'foo',
+        connection: 'bar',
+        attributes: {
+          id: {
+            type: 'integer',
+            autoIncrement: true,
+            primaryKey: true,
+            unique: true
+          },
+          count: {
+            type: 'integer',
+            primaryKey: false
+          },
+          bars: {
+            collection: 'bar',
+            via: 'foos',
+            dominant: true
+          }
+        }
+      };
+
+      collections.bar = {
+        tableName: 'bar',
+        connection: 'bar',
+        attributes: {
+          id: {
+            type: 'integer',
+            autoIncrement: true,
+            primaryKey: true,
+            unique: true
+          },
+          size: {
+            type: 'integer',
+            primaryKey: false
+          },
+          foos: {
+            collection: 'foo',
+            via: 'bars'
+          }
+        }
+      };
+    });
+
+    it('should only use columns with primaryKey set to true for the junction table', function() {
+      var obj = new JoinTables(collections);
+      assert(obj.bar_foos__foo_bars);
+      assert(obj.bar_foos__foo_bars.attributes);
+
+      assert(obj.bar_foos__foo_bars.attributes.foo_bars);
+      assert(obj.bar_foos__foo_bars.attributes.foo_bars.on === 'id');
+
+      assert(obj.bar_foos__foo_bars.attributes.bar_foos);
+      assert(obj.bar_foos__foo_bars.attributes.bar_foos.on === 'id');
+    });
+  });
+
   describe('auto mapping of foreign keys', function() {
     var collections = {};
 


### PR DESCRIPTION
Here is the fix together with the unit tests which no longer fail.
