### PR TITLE
Feature/autotk size control

### DIFF
--- a/lib/waterline-schema/attributes.js
+++ b/lib/waterline-schema/attributes.js
@@ -223,7 +223,8 @@ Attributes.prototype.autoAttributes = function(collection, connections) {
 
   if(collection.autoTK && !attributes.transactionId) {
     attributes.transactionId = {
-      type: 'string'
+      type: 'string',
+      size: 40
     };
   }
 

--- a/lib/waterline-schema/attributes.js
+++ b/lib/waterline-schema/attributes.js
@@ -101,6 +101,7 @@ Attributes.prototype.setDefaults = function(collection, defaults) {
     autoPK: true,
     autoCreatedAt: true,
     autoUpdatedAt: true,
+    destroyMode: 'hard',
     autoTK: true,
     migrate: 'alter'
   };
@@ -110,6 +111,7 @@ Attributes.prototype.setDefaults = function(collection, defaults) {
   if(hop(defaults, 'autoCreatedAt')) defaultSettings.autoCreatedAt = defaults.autoCreatedAt;
   if(hop(defaults, 'autoUpdatedAt')) defaultSettings.autoUpdatedAt = defaults.autoUpdatedAt;
   if(hop(defaults, 'autoTK')) defaultSettings.autoTK = defaults.autoTK;
+  if(hop(defaults, 'destroyMode')) defaultSettings.destroyMode = defaults.destroyMode;
   if(hop(defaults, 'migrate')) defaultSettings.migrate = defaults.migrate;
 
   // Override defaults with collection defined values
@@ -117,6 +119,7 @@ Attributes.prototype.setDefaults = function(collection, defaults) {
   if(hop(collection, 'autoCreatedAt')) defaultSettings.autoCreatedAt = collection.autoCreatedAt;
   if(hop(collection, 'autoUpdatedAt')) defaultSettings.autoUpdatedAt = collection.autoUpdatedAt;
   if(hop(collection, 'autoTK')) defaultSettings.autoTK = collection.autoTK;
+  if(hop(collection, 'destroyMode')) defaultSettings.destroyMode = collection.destroyMode;
   if(hop(collection, 'migrate')) defaultSettings.migrate = collection.migrate;
 
   var flags = {
@@ -124,6 +127,7 @@ Attributes.prototype.setDefaults = function(collection, defaults) {
     autoCreatedAt: defaultSettings.autoCreatedAt,
     autoUpdatedAt: defaultSettings.autoUpdatedAt,
     autoTK: defaultSettings.autoTK,
+    destroyMode: defaultSettings.destroyMode,
     migrate: defaultSettings.migrate
   };
 
@@ -217,9 +221,15 @@ Attributes.prototype.autoAttributes = function(collection, connections) {
     attributes.updatedAt = now;
   }
 
-  if(collection.autoTK && !attributes[collection.autoTK]) {
+  if(collection.autoTK && !attributes.transactionId) {
     attributes.transactionId = {
       type: 'string'
+    };
+  }
+
+  if(collection.destroyMode === 'soft' && !attributes.deleted) {
+    attributes.deleted = {
+      type: 'boolean'
     };
   }
 

--- a/lib/waterline-schema/attributes.js
+++ b/lib/waterline-schema/attributes.js
@@ -101,6 +101,7 @@ Attributes.prototype.setDefaults = function(collection, defaults) {
     autoPK: true,
     autoCreatedAt: true,
     autoUpdatedAt: true,
+    autoTK: true,
     migrate: 'alter'
   };
 
@@ -108,18 +109,21 @@ Attributes.prototype.setDefaults = function(collection, defaults) {
   if(hop(defaults, 'autoPK')) defaultSettings.autoPK = defaults.autoPK;
   if(hop(defaults, 'autoCreatedAt')) defaultSettings.autoCreatedAt = defaults.autoCreatedAt;
   if(hop(defaults, 'autoUpdatedAt')) defaultSettings.autoUpdatedAt = defaults.autoUpdatedAt;
+  if(hop(defaults, 'autoTK')) defaultSettings.autoTK = defaults.autoTK;
   if(hop(defaults, 'migrate')) defaultSettings.migrate = defaults.migrate;
 
   // Override defaults with collection defined values
   if(hop(collection, 'autoPK')) defaultSettings.autoPK = collection.autoPK;
   if(hop(collection, 'autoCreatedAt')) defaultSettings.autoCreatedAt = collection.autoCreatedAt;
   if(hop(collection, 'autoUpdatedAt')) defaultSettings.autoUpdatedAt = collection.autoUpdatedAt;
+  if(hop(collection, 'autoTK')) defaultSettings.autoTK = collection.autoTK;
   if(hop(collection, 'migrate')) defaultSettings.migrate = collection.migrate;
 
   var flags = {
     autoPK: defaultSettings.autoPK,
     autoCreatedAt: defaultSettings.autoCreatedAt,
     autoUpdatedAt: defaultSettings.autoUpdatedAt,
+    autoTK: defaultSettings.autoTK,
     migrate: defaultSettings.migrate
   };
 
@@ -211,6 +215,12 @@ Attributes.prototype.autoAttributes = function(collection, connections) {
 
   if(collection.autoUpdatedAt && !attributes.updatedAt) {
     attributes.updatedAt = now;
+  }
+
+  if(collection.autoTK && !attributes[collection.autoTK]) {
+    attributes.transactionId = {
+      type: 'string'
+    };
   }
 
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "waterline-schema",
   "description": "The core schema builder used in the Waterline ORM.",
-  "version": "0.1.18",
+  "version": "0.1.18-postman.1",
   "contributors": [
     {
       "name": "particlebanana",
@@ -27,7 +27,8 @@
   "homepage": "http://github.com/balderdashy/waterline-schema",
   "main": "lib/waterline-schema.js",
   "scripts": {
-    "test": "make test"
+    "test": "make test",
+    "test-unit": "make test-unit"
   },
   "engines": {
     "node": "*"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "waterline-schema",
   "description": "The core schema builder used in the Waterline ORM.",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "contributors": [
     {
       "name": "particlebanana",

--- a/test/attributes.js
+++ b/test/attributes.js
@@ -13,6 +13,7 @@ describe('Attributes', function() {
         autoPK: false,
         autoCreatedAt: false,
         autoUpdatedAt: false,
+        autoTK: false,
         attributes: {
           foo: 'string',
           bar: 'string',
@@ -65,12 +66,13 @@ describe('Attributes', function() {
       var coll = collectionFn();
       var obj = new Attributes([coll]);
       assert(obj.foo);
-      assert(Object.keys(obj.foo.attributes).length === 5);
+      assert(Object.keys(obj.foo.attributes).length === 6);
       assert(obj.foo.attributes.foo);
       assert(obj.foo.attributes.bar);
       assert(obj.foo.attributes.id);
       assert(obj.foo.attributes.createdAt);
       assert(obj.foo.attributes.updatedAt);
+      assert(obj.foo.attributes.transactionId);
     });
 
     it('should inject flags into the collection', function() {


### PR DESCRIPTION
This would limit the field size generated for transaction Id (autoTK) to 40 characters. ensuring that utf8mb4 works.