### PR TITLE
Lower the case of linkedCollection

### DIFF
--- a/lib/waterline-schema/joinTables.js
+++ b/lib/waterline-schema/joinTables.js
@@ -491,7 +491,7 @@ JoinTables.prototype.markCustomJoinTables = function(collection) {
   for(var attribute in attributes) {
     if(!hop(attributes[attribute], 'through')) continue;
 
-    var linkedCollection = attributes[attribute].through;
+    var linkedCollection = attributes[attribute].through.toLowerCase();
     this.collections[linkedCollection].throughTable = this.collections[linkedCollection].throughTable || {};
     var throughPath = collection + '.' + attribute;
     var linkedAttrs = this.collections[linkedCollection].attributes;


### PR DESCRIPTION
ThroughTable name must be lowercased, otherwise an error is throwed.