### PR TITLE
Update attributes.js

### DIFF
--- a/lib/waterline-schema/attributes.js
+++ b/lib/waterline-schema/attributes.js
@@ -213,7 +213,7 @@ Attributes.prototype.autoAttributes = function(collection, connections) {
   // Extend definition with autoUpdatedAt and autoCreatedAt timestamps
   var now = {
     type: 'datetime',
-    'default': 'NOW'
+    //'default': 'NOW'
   };
 
   if(collection.autoCreatedAt && !attributes[collection.autoCreatedAt]) {


### PR DESCRIPTION
'Unknown rule: default' error fix on attribute validation.
On using custom name for createdAt, updatedAt (e.g. autoCreatedAt: 'created_at') with the latest sailsjs