### PR TITLE
Sort join table collection/attribute names to ensure consistent identities

### DIFF
--- a/lib/waterline-schema/helpers/build-join-table-schema.js
+++ b/lib/waterline-schema/helpers/build-join-table-schema.js
@@ -22,17 +22,16 @@ module.exports = function buildJoinTableSchema(tableDef, schema, modelDefaults) 
 
   // Build a default table name for the collection
   var identity = (function buildIdentity() {
-
     // Sort the two sides of the assocation so that we always get a consistent join table identity.
-    var cols = [c1, c2].sort(function(a, b) {
+    var cols = [c1, c2].sort(function sortAssociations(a, b) {
       // If the two sides refer to the same collection, sort by attribute name.
-      if (a.collection === b.collection) { return a.attribute > b.attribute; }
+      if (a.collection === b.collection) {
+        return a.attribute > b.attribute;
+      }
       // Otherwise sort by collection name.
       return a.collection > b.collection;
     });
-
     return cols[0].collection + '_' + cols[0].attribute + '__' + cols[1].collection + '_' + cols[1].attribute;
-
   })();
 
 

--- a/lib/waterline-schema/helpers/build-join-table-schema.js
+++ b/lib/waterline-schema/helpers/build-join-table-schema.js
@@ -27,7 +27,7 @@ module.exports = function buildJoinTableSchema(tableDef, schema, modelDefaults) 
     var cols = [c1, c2].sort(function(a, b) {
       // If the two sides refer to the same collection, sort by attribute name.
       if (a.collection === b.collection) { return a.attribute > b.attribute; }
-      // Otherwise sort by collection na,e.
+      // Otherwise sort by collection name.
       return a.collection > b.collection;
     });
 

--- a/lib/waterline-schema/helpers/build-join-table-schema.js
+++ b/lib/waterline-schema/helpers/build-join-table-schema.js
@@ -26,10 +26,10 @@ module.exports = function buildJoinTableSchema(tableDef, schema, modelDefaults) 
     var cols = [c1, c2].sort(function sortAssociations(a, b) {
       // If the two sides refer to the same collection, sort by attribute name.
       if (a.collection === b.collection) {
-        return a.attribute > b.attribute;
+        return (a.attribute > b.attribute) ? 1 : -1;
       }
       // Otherwise sort by collection name.
-      return a.collection > b.collection;
+      return (a.collection > b.collection) ? 1 : -1;
     });
     return cols[0].collection + '_' + cols[0].attribute + '__' + cols[1].collection + '_' + cols[1].attribute;
   })();

--- a/lib/waterline-schema/helpers/build-join-table-schema.js
+++ b/lib/waterline-schema/helpers/build-join-table-schema.js
@@ -22,11 +22,17 @@ module.exports = function buildJoinTableSchema(tableDef, schema, modelDefaults) 
 
   // Build a default table name for the collection
   var identity = (function buildIdentity() {
-    if (c1.collection < c2.collection) {
-      return c1.collection + '_' + c1.attribute + '__' + c2.collection + '_' + c2.attribute;
-    }
 
-    return c2.collection + '_' + c2.attribute + '__' + c1.collection + '_' + c1.attribute;
+    // Sort the two sides of the assocation so that we always get a consistent join table identity.
+    var cols = [c1, c2].sort(function(a, b) {
+      // If the two sides refer to the same collection, sort by attribute name.
+      if (a.collection === b.collection) { return a.attribute > b.attribute; }
+      // Otherwise sort by collection na,e.
+      return a.collection > b.collection;
+    });
+
+    return cols[0].collection + '_' + cols[0].attribute + '__' + cols[1].collection + '_' + cols[1].attribute;
+
   })();
 
 

--- a/test/joinTables.js
+++ b/test/joinTables.js
@@ -277,7 +277,7 @@ describe('Join Table Mapper :: ', function() {
 
       assert.equal(schema.foo.schema.isFollowing.references, 'foo_followedBy__foo_isFollowing');
       assert.equal(schema.foo.schema.isFollowing.on, 'foo_isFollowing');
-      assert.equal(schema.foo.schema.followedBy.references, 'foo_isFollowing__foo_followedBy');
+      assert.equal(schema.foo.schema.followedBy.references, 'foo_followedBy__foo_isFollowing');
       assert.equal(schema.foo.schema.followedBy.on, 'foo_followedBy');
     });
   });


### PR DESCRIPTION
This fixes an issue w/ reflexive associations where one side would have `referenceIdentity: 'pet_children__pet_parents'` and the other would have `referenceIdentity: 'pet_parents__pet_children'` even though only one of those join tables actually existed.