### PR TITLE
allow column type to be set on foreign keys

### DIFF
--- a/lib/waterline-schema/foreignKeys.js
+++ b/lib/waterline-schema/foreignKeys.js
@@ -47,17 +47,22 @@ module.exports = function foreignKeysMapper(schema) {
       // Find the primary key of the referenced model. This will be used to set
       // the rules regarding how the association is built. For a `model` type
       // association the foreign key will the value of the related model's
-      // primary key.
+      // primary key unless a value is specifically defined.
       var relatedPrimaryKeyField = relatedModel.primaryKey;
       var relatedPrimaryKey = relatedModel.schema[relatedPrimaryKeyField];
       if (!relatedPrimaryKey) {
         throw new Error('The model association defined for attribute ' + attributeName + ' on the ' + collection.identity + ' model points to a model that doesn\'t have a primary key field.');
       }
 
+      // Set the type of the attribute to either the inferred value or the
+      // specified value.
+      var autoMigrations = attributeVal.autoMigrations || {};
+      var columnType = autoMigrations.columnType || relatedPrimaryKey.type;
+
       // Expand the attribute value to include information on the association.
       var foreignKey = {
         columnName: attributeVal.columnName,
-        type: relatedPrimaryKey.type,
+        type: columnType,
         foreignKey: true,
         references: relatedModel.tableName,
         referenceIdentity: relatedModelName,

--- a/test/foreignKeys.js
+++ b/test/foreignKeys.js
@@ -135,4 +135,72 @@ describe('Foreign Key Mapper :: ', function() {
       assert.equal(barSchema.foo.on, 'id');
     });
   });
+
+  describe('With custom column type', function() {
+    var schema;
+
+    before(function() {
+      var fixtures = [
+        {
+          identity: 'foo',
+          primaryKey: 'id',
+          attributes: {
+            id: {
+              type: 'string'
+            }
+          }
+        },
+        {
+          identity: 'bar',
+          primaryKey: 'id',
+          attributes: {
+            id: {
+              type: 'number'
+            },
+            foo: {
+              model: 'foo',
+              autoMigrations: {
+                columnType: 'foobar'
+              }
+            }
+          }
+        }
+      ];
+
+      var collections = _.map(fixtures, function(obj) {
+        var collection = function() {};
+        collection.prototype = obj;
+        return collection;
+      });
+
+      // Build the schema
+      schema = SchemaBuilder(collections);
+    });
+
+    /**
+     * Test that a foreign key gets built for the bar table in the following structure:
+     *
+     * attributes: {
+     *   foo: {
+     *     columnName: 'foo',
+     *     type: 'number',
+     *     foreignKey: true,
+     *     references: 'foo',
+     *     on: 'id'
+     *   }
+     * }
+     */
+
+    it('should add a foreign key mapping to the bar collection', function() {
+      // Map out the foreign keys
+      ForeignKeyMapper(schema);
+      var barSchema = schema.bar.schema;
+
+      assert.equal(barSchema.foo.columnName, 'foo');
+      assert.equal(barSchema.foo.type, 'foobar');
+      assert.equal(barSchema.foo.foreignKey, true);
+      assert.equal(barSchema.foo.references, 'foo');
+      assert.equal(barSchema.foo.on, 'id');
+    });
+  });
 });


### PR DESCRIPTION
Allows you to specify custom column types on foreign keys instead of just grabbing the model's primary key type.