### PR TITLE
Cannot set indexes with 'sails-mysql' adapter

### DIFF
--- a/accessible/valid-attribute-properties.js
+++ b/accessible/valid-attribute-properties.js
@@ -29,5 +29,6 @@ module.exports = [
   'required',
   'validations',
   'allowNull',
-  'description'
+  'description',
+  'index'
 ];


### PR DESCRIPTION
Regarding to [sails-mysql](https://github.com/balderdashy/sails-mysql) adapter's code, [it supports index properties](https://github.com/balderdashy/sails-mysql/blob/master/helpers/private/schema/build-indexes.js#L41). 

However `waterline-schema` package rejects it with following error:

> Error: The attribute user on the topic model contains invalid properties. The property index isn't a recognized property.

Responsible code: 

    _.each(attribute, function parseProperties(propertyValue, propertyName) {
      if (_.indexOf(validProperties, propertyName) < 0) {
        throw new Error('The attribute `' + attributeName + '` on the `' + collection.identity + '` model contains invalid properties. The property `' + propertyName + '` isn\'t a recognized property.');
      }
    });

Looks like, you just forgot to allow `index` properties [in here](https://github.com/balderdashy/waterline-schema/blob/master/accessible/valid-attribute-properties.js).