### PR TITLE
Suggested model property validation additions and/or a different way (see below)

### DIFF
--- a/accessible/valid-attribute-properties.js
+++ b/accessible/valid-attribute-properties.js
@@ -47,4 +47,5 @@ module.exports = [
   'moreInfoUrl',
   'example',
   'protect',
+  'label',
 ];

--- a/accessible/valid-attribute-properties.js
+++ b/accessible/valid-attribute-properties.js
@@ -47,5 +47,14 @@ module.exports = [
   'moreInfoUrl',
   'example',
   'protect',
+
+  // Request for Helm generator capabilities, for great, quick prototypes.  See commit log for explanation
   'label',
+  'hideFromTable',
+  'hideFromForm',
+  'notEditable',
+  'toolTip',
+  'filterable',
+  'beforeFormRender',  // fn
+  'beforeIndexRender', // fn
 ];


### PR DESCRIPTION
Hi there, Mike.  We are working on building a CRUD model generator for SAILSJS and the model schema validations are throwing things off. In our opinion, any model property validation prevents extending the system with dynamic capabilities. There may be a security reason for validating model properties, but if there's not, we recommend removing the model property validation all together (line 237-241 in /lib/waterline-schema/schema.js).  Another option is to allow us to register our own model property types that the validator can validate against.  Thank you for considering our ideas as a feature request and a way to make great software, quickly. -- David

p.s. hope you guys are doing well!