### PR TITLE
Flexible attribute properties patch

### DIFF
--- a/lib/waterline-schema/schema.js
+++ b/lib/waterline-schema/schema.js
@@ -134,7 +134,7 @@ module.exports = function schemaBuilder(collections) {
       attributes: _.merge({}, collection.attributes),
       //Allow the attribute properties to be flexibly defined, 
       //e.g. phone: {type:"string", isMobilePhone:true, isXYZProperty:false}
-      attributeMode: collection.attributeMode && collection.attributeMode === "flexible" || "strict",
+      attributeWhitelist: collection.attributeWhitelist && collection.attributeWhitelist === "flexible" || "strict",
       // The schema piece will be transformed along the way to reflect the
       // underlying datastructure. i.e. expanding out associations into foreign
       // keys, etc.
@@ -237,7 +237,7 @@ module.exports = function schemaBuilder(collections) {
       //   ╚╝ ╩ ╩╩═╝╩═╩╝╩ ╩ ╩ ╚═╝  ┴  ┴└─└─┘┴  └─┘┴└─ ┴ ┴└─┘└─┘
       // If the attribute contains a property that isn't whitelisted, then return
       // an error.
-      if (schemaCollection.attributeMode === "strict") {
+      if (schemaCollection.attributeWhitelist === "strict") {
         _.each(attribute, function parseProperties(propertyValue, propertyName) {
           if (_.indexOf(validProperties, propertyName) < 0) {
             throw flaverr({ name: 'userError' }, Error('The attribute `' + attributeName + '` on the `' + collection.identity + '` model contains invalid properties. The property `' + propertyName + '` isn\'t a recognized property.'));

--- a/lib/waterline-schema/schema.js
+++ b/lib/waterline-schema/schema.js
@@ -132,6 +132,9 @@ module.exports = function schemaBuilder(collections) {
       tableName: collection.tableName,
       datastore: collection.datastore || collection.connection,
       attributes: _.merge({}, collection.attributes),
+      //Allow the attribute properties to be flexibly defined, 
+      //e.g. phone: {type:"string", isMobilePhone:true, isXYZProperty:false}
+      attributeMode: collection.attributeMode && collection.attributeMode === "flexible" || "strict",
       // The schema piece will be transformed along the way to reflect the
       // underlying datastructure. i.e. expanding out associations into foreign
       // keys, etc.
@@ -234,11 +237,13 @@ module.exports = function schemaBuilder(collections) {
       //   ╚╝ ╩ ╩╩═╝╩═╩╝╩ ╩ ╩ ╚═╝  ┴  ┴└─└─┘┴  └─┘┴└─ ┴ ┴└─┘└─┘
       // If the attribute contains a property that isn't whitelisted, then return
       // an error.
-      _.each(attribute, function parseProperties(propertyValue, propertyName) {
-        if (_.indexOf(validProperties, propertyName) < 0) {
-          throw flaverr({ name: 'userError' }, Error('The attribute `' + attributeName + '` on the `' + collection.identity + '` model contains invalid properties. The property `' + propertyName + '` isn\'t a recognized property.'));
-        }
-      });
+      if (schemaCollection.attributeMode === "strict") {
+        _.each(attribute, function parseProperties(propertyValue, propertyName) {
+          if (_.indexOf(validProperties, propertyName) < 0) {
+            throw flaverr({ name: 'userError' }, Error('The attribute `' + attributeName + '` on the `' + collection.identity + '` model contains invalid properties. The property `' + propertyName + '` isn\'t a recognized property.'));
+          }
+        });
+      }
 
 
       //  ╦  ╦╔═╗╦  ╦╔╦╗╔═╗╔╦╗╔═╗  ┌─┐┬  ┬  ┌─┐┬ ┬╔╗╔┬ ┬┬  ┬


### PR DESCRIPTION
This small change allows a developer to define model attribute properties in anyway they wish. I believe this implementation provides better flexibility in model attribute definitions while maintaining backwards compatibility for those who rely upon the attribute whitelist (likely unknowingly). 

`attributeWhitelist : "flexible"` 

can be defined on a per model basis or with config/model.js to make this change globally. 