### PR TITLE
Allow whitelisted model attribute properties

### DIFF
--- a/lib/waterline-schema/schema.js
+++ b/lib/waterline-schema/schema.js
@@ -241,7 +241,9 @@ module.exports = function schemaBuilder(collections) {
         ignoreProperties = collection.validations.ignoreProperties;
       }
       _.each(attribute, function parseProperties(propertyValue, propertyName) {
-        if (_.indexOf(ignoreProperties, propertyName) >= 0) return;
+        if (_.indexOf(ignoreProperties, propertyName) >= 0) {
+          return;
+        }
         if (_.indexOf(validProperties, propertyName) < 0) {
           throw flaverr({ name: 'userError' }, Error('The attribute `' + attributeName + '` on the `' + collection.identity + '` model contains invalid properties. The property `' + propertyName + '` isn\'t a recognized property.'));
         }

--- a/lib/waterline-schema/schema.js
+++ b/lib/waterline-schema/schema.js
@@ -234,7 +234,14 @@ module.exports = function schemaBuilder(collections) {
       //   ╚╝ ╩ ╩╩═╝╩═╩╝╩ ╩ ╩ ╚═╝  ┴  ┴└─└─┘┴  └─┘┴└─ ┴ ┴└─┘└─┘
       // If the attribute contains a property that isn't whitelisted, then return
       // an error.
+      // Allow properties whitelisted in 'ignoreProperties', typically in `config/models.js`
+      // in `validations.ignoreProperties` array.
+      var ignoreProperties = [];
+      if (_.has(collection, 'validations') && _.has(collection.validations, 'ignoreProperties') && _.isArray(collection.validations.ignoreProperties)) {
+        ignoreProperties = collection.validations.ignoreProperties;
+      }
       _.each(attribute, function parseProperties(propertyValue, propertyName) {
+        if (_.indexOf(ignoreProperties, propertyName) >= 0) return;
         if (_.indexOf(validProperties, propertyName) < 0) {
           throw flaverr({ name: 'userError' }, Error('The attribute `' + attributeName + '` on the `' + collection.identity + '` model contains invalid properties. The property `' + propertyName + '` isn\'t a recognized property.'));
         }


### PR DESCRIPTION
Allow model attribute properties whitelisted in config/models.js: validations.ignoreProperties[].

This was previously possible in waterline v0.11.12. See [waterline/lib/waterline/core/validations.js](https://github.com/balderdashy/waterline/blob/v0.11.12/lib/waterline/core/validations.js), specifically [line 64-66](https://github.com/balderdashy/waterline/blob/af447bae32cb705f1eb981b1cf82521a45f31f9d/lib/waterline/core/validations.js#L64).

Happy to submit PR for documentation update if this is accepted.

Please advise if this should be handled another way.